### PR TITLE
Update maven-invoker-plugin to 3.2.2 to fix JDK16 build

### DIFF
--- a/.github/workflows/jdkbuilds.yml
+++ b/.github/workflows/jdkbuilds.yml
@@ -30,10 +30,10 @@ jobs:
   openjdk:
     strategy:
       matrix:
-        jdk: [8-slim, 11-slim, 13, 14]
+        jdk: [8-slim, 11-slim, 15, 16]
     name: "OpenJDK ${{ matrix.jdk }}"
     runs-on: ubuntu-latest
-    container: "maven:3.6.3-jdk-${{ matrix.jdk }}"
+    container: "maven:3.6.3-openjdk-${{ matrix.jdk }}"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1


### PR DESCRIPTION
Fixes these problems in the JDK16 build:

[INFO] run post-build script verify.bsh
[INFO]   The post-build script did not succeed. Sourced file: inline evaluation of: ``import java.io.*; import java.util.regex.*;  try {     File file = new File( bas . . . '' unknown error: Unable to make public java.lang.AbstractStringBuilder java.lang.AbstractStringBuilder.append(java.lang.String) accessible: module java.base does not "opens java.lang" to unnamed module @430c04a6
[INFO]           it-update-child-modules-002/pom.xml .............. FAILED (6.3 s)